### PR TITLE
Don't require Chaplin.

### DIFF
--- a/controllers/session_controller.coffee
+++ b/controllers/session_controller.coffee
@@ -1,4 +1,3 @@
-Chaplin = require 'chaplin'
 Controller = require 'controllers/base/controller'
 User = require 'models/user'
 LoginView = require 'views/login-view'

--- a/lib/services/service_provider.coffee
+++ b/lib/services/service_provider.coffee
@@ -1,5 +1,4 @@
 utils = require 'lib/utils'
-Chaplin = require 'chaplin'
 
 module.exports = class ServiceProvider
   # Mixin an Event Broker

--- a/lib/utils.coffee
+++ b/lib/utils.coffee
@@ -1,5 +1,3 @@
-Chaplin = require 'chaplin'
-
 # Application-specific utilities
 # ------------------------------
 


### PR DESCRIPTION
I followed the steps in the readme and these lines raised exceptions (module not found). I'm not sure why they're needed since Chaplin is available inside an app. ostio also doesn't have these lines.
